### PR TITLE
docs: Add ADRs for architecture, infra, CI/CD, and security

### DIFF
--- a/InventoryManagement.slnx
+++ b/InventoryManagement.slnx
@@ -1,9 +1,7 @@
 <Solution>
   <Folder Name="/Governance/">
     <File Path=".github/copilot-instructions.md" />
-    <File Path=".github/workflows/ci-tests.yml" />
     <File Path=".gitignore" />
-    <File Path="codecov.yml" />
   </Folder>
   <Project Path="docker-compose.dcproj">
     <Build />

--- a/docs/adr/0001-adopt-clean-architecture.md
+++ b/docs/adr/0001-adopt-clean-architecture.md
@@ -1,0 +1,10 @@
+﻿1. Adopt Clean Architecture
+Status: Accepted
+
+Context: Need to isolate the business domain (inventory management) from delivery technologies (APIs, databases) and frameworks, ensuring long-term maintainability, technological independence, and high testability (xUnit).
+
+Decision: Clean Architecture structured in 4 layers (API, Application, Domain, Infrastructure) and SOLID principles in .NET 10.
+
+Consequences:
+- Positive: We gain high testability, low coupling, and flexibility to replace infrastructure providers.
+- Negative: We lose initial development speed due to architectural verbosity and proliferation of abstractions (interfaces, mappings) in simple use cases (basic CRUDs).

--- a/docs/adr/0002-strict-containerization.md
+++ b/docs/adr/0002-strict-containerization.md
@@ -1,0 +1,10 @@
+﻿2. Strict containerization
+Status: Accepted
+
+Context: Deployment requires zero-cost leveraging of the Azure for Students 750h/month free tier. The 1GB RAM and 64GB SSD constraints demand a lightweight host OS, mandatory Swap file configuration (1GB), and container log rotation to prevent disk exhaustion.
+
+Decision: Strict containerization via Docker Engine on an Azure B1s Linux VM (Ubuntu 24.04), fronted by an Nginx Reverse Proxy (HTTPS/Let's Encrypt) and strict Docker log-driver limits (max-size: 10m).
+
+Consequences:
+- Positive: We gain exact environment parity, predictable routing, and zero hosting costs.
+- Negative: We lose PaaS conveniences, assuming full responsibility for OS hardening (UFW, Fail2Ban), SSH key management, and reverse proxy maintenance.

--- a/docs/adr/0003-azure-database-for-postgresql.md
+++ b/docs/adr/0003-azure-database-for-postgresql.md
@@ -1,0 +1,10 @@
+﻿3. Azure Database for PostgreSQL
+Status: Accepted
+
+Context: Need for strong transactional consistency (ACID) for physical inventory movements, combined with strict Zero Trust network security. The database must not be exposed to the public internet to prevent brute-force attacks.
+
+Decision: Azure Database for PostgreSQL Flexible Server (B1ms Tier) managed by Entity Framework Core 10, deployed within a delegated Azure Virtual Network (VNet) with Private Access.
+
+Consequences:
+- Positive: We gain relational integrity, optimized queries delegated to the ORM, and absolute network-level security.
+- Negative: We lose the ease of connecting to the database directly from local developer machines without a VPN or SSH tunnel.

--- a/docs/adr/0004-automated-ef-core-migrations.md
+++ b/docs/adr/0004-automated-ef-core-migrations.md
@@ -1,0 +1,10 @@
+﻿4. Automated EF Core Migrations
+Status: Accepted
+
+Context: Immediate coupling to the migration system during prototyping causes Model Drift, but using EnsureCreated in production environments poses a critical architectural risk of data loss and schema mismatch.
+
+Decision: Automated EF Core Migrations for database schema evolution, abandoning EnsureCreatedAsync.
+
+Consequences:
+- Positive: We gain deterministic, idempotent schema deployments and a strict CI/CD alignment for DevOps data management.
+- Negative: We lose the extreme speed of dynamic database recreation during the initial domain engineering phase.

--- a/docs/adr/0005-distributed-caching-redis.md
+++ b/docs/adr/0005-distributed-caching-redis.md
@@ -1,0 +1,10 @@
+﻿5. Distributed Caching with Redis and Polly
+Status: Accepted
+
+Context: Unacceptable risk of inventory corruption due to duplicated POST requests. Need to relieve the PostgreSQL database from repetitive catalog read queries while handling potential network instability between the Azure VM and the Redis Cloud instance.
+
+Decision: Distributed caching via Redis Enterprise Cloud (GitHub Student Pack) using IDistributedCache, combined with Polly for transient fault handling (Circuit Breaker/Retries).
+
+Consequences:
+- Positive: We gain strict state consistency, sub-millisecond read latency for catalogs, and high resilience against third-party API timeouts.
+- Negative: We add structural complexity to the request flow and dependency on an external cloud cache provider.

--- a/docs/adr/0006-dual-layer-security.md
+++ b/docs/adr/0006-dual-layer-security.md
@@ -1,0 +1,10 @@
+﻿6. Dual-layer security
+Status: Accepted
+
+Context: Mandatory mitigation of malicious script injection vectors (Cross-Site Scripting) in free-text fields, while simultaneously protecting the Azure VM's public IP from Layer 7 DDoS attacks without incurring Azure Web Application Firewall costs.
+
+Decision: Dual-layer security: Edge WAF and DNS masking via Cloudflare, combined with Application-level Input Sanitization (HtmlSanitizer) for Anti-XSS.
+
+Consequences:
+- Positive: We gain defense-in-depth security, masking the true infrastructure IP, and guaranteeing clean data persistence.
+- Negative: We lose some CPU cycles on the backend due to HTML/Regex parsing latency before business rule execution.

--- a/docs/adr/0007-apm-and-monitoring.md
+++ b/docs/adr/0007-apm-and-monitoring.md
@@ -1,0 +1,10 @@
+﻿7. APM and Infrastructure Monitoring
+Status: Accepted
+
+Context: Local structured logging containers consume excessive RAM and disk space, threatening the Azure B1s VM constraints. Leveraging GitHub Student Pack tools provides Enterprise-grade observability at zero cost.
+
+Decision: APM and infrastructure monitoring via Datadog Agent (OS-level), coupled with Sentry for real-time application crash reporting.
+
+Consequences:
+- Positive: We gain advanced audit capabilities, granular stack-trace capture, and infrastructure metrics without consuming the VM's resources.
+- Negative: We introduce vendor lock-in with Datadog/Sentry and rely on outbound network calls to transmit telemetry data.

--- a/docs/adr/0008-ci-cd-quality-gate.md
+++ b/docs/adr/0008-ci-cd-quality-gate.md
@@ -1,0 +1,10 @@
+﻿8. GitHub Actions CI/CD Quality Gate
+Status: Accepted
+
+Context: Need for an automated, rigorous Quality Gate on the main branch to prevent bad code, untested logic, or architectural violations from being merged, utilizing native and free Student Pack tools instead of relying on local GPU/LLM infrastructure.
+
+Decision: GitHub Actions workflow integrating xUnit, Codecov (strict 80% coverage threshold), CodeQL (SAST), and GitHub Copilot Code Review.
+
+Consequences:
+- Positive: We gain a highly automated, senior-level CI/CD pipeline, absolute deployment confidence, and semantic AI reviews without managing local LLM infrastructure.
+- Negative: We increase the Pull Request feedback loop time and strictly block rapid, untested hotfixes.

--- a/docs/adr/0009-async-email-alerts.md
+++ b/docs/adr/0009-async-email-alerts.md
@@ -1,0 +1,10 @@
+﻿9. Async Email Alerts
+Status: Accepted
+
+Context: Critical inventory level alerts must be dispatched without blocking the main HTTP request thread. Standard SMTP is blocked by Azure (Port 25), necessitating HTTP API integration.
+
+Decision: Asynchronous email alerts via SendGrid API orchestrated by .NET BackgroundServices (IHostedService) and the Outbox Pattern.
+
+Consequences:
+- Positive: We gain non-blocking HTTP responses and reliable email delivery.
+- Negative: We add architectural complexity by introducing background workers and eventual consistency in the notification flow.

--- a/docs/adr/0010-centralized-configuration.md
+++ b/docs/adr/0010-centralized-configuration.md
@@ -1,0 +1,10 @@
+﻿10. Centralized Configuration Management
+Status: Accepted
+
+Context: Storing Connection Strings, JWT secrets, or API keys in .env files or the repository violates compliance and security standards.
+
+Decision: Centralized configuration and secrets management using Azure Key Vault accessed via Azure Managed Identities.
+
+Consequences:
+- Positive: We gain military-grade cryptographic storage and passwordless database authentication.
+- Negative: We add a slight latency overhead during application startup to fetch secrets from the vault.


### PR DESCRIPTION
docs: Add ADRs for architecture, infra, CI/CD, and security

Added ten Architecture Decision Records (ADRs) detailing key decisions on Clean Architecture, containerization, PostgreSQL, EF Core migrations, Redis caching with Polly, dual-layer security, APM/monitoring, CI/CD quality gates, async email alerts, and centralized config management. Also removed CI workflow and code coverage config references from the solution folder to align with new ADR-driven practices.

Issue #22 